### PR TITLE
Match Ruby version to stock OS X Mavericks. Add Rouge gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
-ruby '2.1.1'
+ruby '2.0.0'
 gem 'bundler'
 gem 'jekyll'
 gem 'rack-jekyll'
+gem 'rouge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
     rb-kqueue (0.2.3)
       ffi (>= 0.5.0)
     redcarpet (2.3.0)
+    rouge (1.6.2)
     safe_yaml (1.0.3)
     toml (0.1.1)
       parslet (~> 1.5.0)
@@ -55,3 +56,4 @@ DEPENDENCIES
   bundler
   jekyll
   rack-jekyll
+  rouge


### PR DESCRIPTION
No sense in requiring people to upgrade their system Ruby.  Maybe even consider lowering this to whatever ships on Mountain Lion too?
Also add gem needed by the BS pages so `bundle install` will make `jekyll serve` work correctly.
